### PR TITLE
Commit prot

### DIFF
--- a/app/assets/javascripts/proto_edit.js
+++ b/app/assets/javascripts/proto_edit.js
@@ -1,5 +1,6 @@
 $(function(){
   // main_image_preview/////////////////
+  var max_subs = 3
   $("#main_image_uploader").find("input").on("change", function(e) {
     var file = e.target.files[0];
     var reader = new FileReader();
@@ -38,7 +39,8 @@ $(function(){
     })
   })
 
-  //add_picture
+  //add_picture///////////////////////////////////////////////
+    //画像投稿フォームの差し込み
   function buildHtml(i){
     var html = `<li class="list-group-item col-md-4 new_sub edit_subs" style="display:none;">
         <div class="image-upload">
@@ -51,6 +53,7 @@ $(function(){
     return html;
   }
 
+    //画像追加ボタンの差し込み
   function buildAddSub(){
     var add_sub  = `<li class="list-group-item col-md-4" id="add_sub" >
         <div>
@@ -60,9 +63,10 @@ $(function(){
 
     return add_sub;
   }
+    //条件を見極めて、画像フォームと画像追加ボタンを差し込んでうr
   if (location.pathname.match(/\/prototypes\/\d+\/edit/)){
     var sub_count = $(".edit_subs").length
-    var need_new = 3 - sub_count
+    var need_new = max_subs - sub_count
     if (sub_count == 0){
       var num = 1
     }
@@ -82,11 +86,11 @@ $(function(){
     }
   }
 
-  $("body").on("click" ,$("#add_sub"), function(){
+  $("#add_sub").on("click", function(){
     var target = $(".edit_subs")[sub_count];
     $(target).css("display", "block");
     sub_count += 1;
-    if(sub_count == 3){
+    if(sub_count == max_subs){
       $("#add_sub").css("display", "none");
     }
   })

--- a/app/assets/javascripts/proto_edit.js
+++ b/app/assets/javascripts/proto_edit.js
@@ -1,10 +1,9 @@
 $(function(){
   // main_image_preview/////////////////
   var max_subs = 3
-  $("#main_image_uploader").find("input").on("change", function(e) {
+  $(".main_image_uploader").find("input").on("change", function(e) {
     var file = e.target.files[0];
     var reader = new FileReader();
-
     if(file.type.indexOf("image") != 0){
       alert("画像ファイルを選択してください");
       return false;
@@ -12,7 +11,7 @@ $(function(){
 
     reader.onload = (function(){
       return function(e){
-        $("#main_image").attr("src", e.target.result);
+        $(".main_image").attr("src", e.target.result);
       };
     })(file);
     reader.readAsDataURL(file);
@@ -20,10 +19,10 @@ $(function(){
 
   // sub_image_preview///////////////////////
   $('.list-group').on("click", $(this).find(".list-group-item"), function() {
-    $("#sub_image_uploder").find("input").on("change", function(e) {
+    $(".sub_image_uploder").find("input").on("change", function(e) {
       var file = e.target.files[0]
       var reader = new FileReader();
-      var target = $(this).siblings("#sub_image");
+      var target = $(this).siblings(".sub_image");
 
       if(file.type.indexOf("image") != 0){
         alert("画像ファイルを選択してください");

--- a/app/assets/javascripts/proto_edit.js
+++ b/app/assets/javascripts/proto_edit.js
@@ -1,0 +1,93 @@
+$(function(){
+  // main_image_preview/////////////////
+  $("#main_image_uploader").find("input").on("change", function(e) {
+    var file = e.target.files[0];
+    var reader = new FileReader();
+
+    if(file.type.indexOf("image") != 0){
+      alert("画像ファイルを選択してください");
+      return false;
+    }
+
+    reader.onload = (function(){
+      return function(e){
+        $("#main_image").attr("src", e.target.result);
+      };
+    })(file);
+    reader.readAsDataURL(file);
+  })
+
+  // sub_image_preview///////////////////////
+  $('.list-group').on("click", $(this).find(".list-group-item"), function() {
+    $("#sub_image_uploder").find("input").on("change", function(e) {
+      var file = e.target.files[0]
+      var reader = new FileReader();
+      var target = $(this).siblings("#sub_image");
+
+      if(file.type.indexOf("image") != 0){
+        alert("画像ファイルを選択してください");
+        return false;
+      }
+
+      reader.onload = (function(){
+        return function(e){
+          target.attr("src", e.target.result);
+        };
+      })(file);
+      reader.readAsDataURL(file);
+    })
+  })
+
+  //add_picture
+  function buildHtml(i){
+    var html = `<li class="list-group-item col-md-4 new_sub edit_subs" style="display:none;">
+        <div class="image-upload">
+          <img style="width: 100%; height: 100%;" id="sub_image" src="">
+          <input type="file" name="prototype[captured_images_attributes][${i}][content]" id="prototype_captured_images_attributes_${i}_content">
+          <input value="sub" type="hidden" name="prototype[captured_images_attributes][${i}][status]" id="prototype_captured_images_attributes_${i}_status">
+        </div>
+      </li>`
+
+    return html;
+  }
+
+  function buildAddSub(){
+    var add_sub  = `<li class="list-group-item col-md-4" id="add_sub" >
+        <div>
+          追加したいな
+        </div>
+      </li>`
+
+    return add_sub;
+  }
+  if (location.pathname.match(/\/prototypes\/\d+\/edit/)){
+    var sub_count = $(".edit_subs").length
+    var need_new = 3 - sub_count
+    if (sub_count == 0){
+      var num = 1
+    }
+    else{
+      var get_num = $(".edit_subs").find("input").attr("name").match(/\d/)
+      var num = Number(get_num) + sub_count
+    }
+    if(need_new != 0){
+      var target = $(".proto-sub-list")
+      for (i = sub_count; i < need_new + sub_count ; i = i +1){
+        var html = buildHtml(num)
+        num += 1
+        target.append(html);
+      }
+      var add_sub = buildAddSub()
+      target.append(add_sub)
+    }
+  }
+
+  $("body").on("click" ,$("#add_sub"), function(){
+    var target = $(".edit_subs")[sub_count];
+    $(target).css("display", "block");
+    sub_count += 1;
+    if(sub_count == 3){
+      $("#add_sub").css("display", "none");
+    }
+  })
+})

--- a/app/assets/stylesheets/modlues/_base.scss
+++ b/app/assets/stylesheets/modlues/_base.scss
@@ -12,12 +12,11 @@ body {
 	font-size: 14px;
 	line-height: 1.4;
 	color: #212121;
-  
+
 	overflow-x: hidden;
-  
+
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	-moz-font-feature-settings: "liga", "kern";
 }
-  

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :set_prototype, only: [:show, :destroy]
+  before_action :set_prototype, only: [:show, :destroy, :edit, :update]
 
   def index
     @prototypes = Prototype.all
@@ -15,15 +15,25 @@ class PrototypesController < ApplicationController
     if @prototype.save
       redirect_to :root, notice: 'New prototype was successfully created'
     else
-      redirect_to ({ action: new }), alert: 'YNew prototype was unsuccessfully created'
+      render :new
      end
   end
 
   def show
   end
 
+  def edit
+  end
+
+  def update
+    if @prototype.update(prototype_update_params)
+      redirect_to root_path, alert: 'Prototype was successfully Update'
+    else
+      render :edit
+    end
+  end
   def destroy
-    @prototype.destroy 
+    @prototype.destroy
     redirect_to :root, alert: 'Prototype was successfully deleted'
   end
 
@@ -42,6 +52,16 @@ class PrototypesController < ApplicationController
       :concept,
       :user_id,
       captured_images_attributes: [:content, :status]
+    )
+  end
+
+  def prototype_update_params
+    params.require(:prototype).permit(
+      :title,
+      :catch_copy,
+      :concept,
+      :user_id,
+      captured_images_attributes: [:content, :status, :id]
     )
   end
 end

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -10,8 +10,8 @@
       .row
         .col-md-12
           %h4 Main Thumbnail
-          .cover-image-upload#main_image_uploader
-            = image_tag(@prototype.set_main_thumbnail, style: "width: 100%; height: 100%;", id: "main_image")
+          .cover-image-upload.main_image_uploader
+            = image_tag(@prototype.set_main_thumbnail, style: "width: 100%; height: 100%;", class: "main_image")
             = f.fields_for :captured_images  do |image|
               - if image.index == 0
                 = image.file_field :content, value: image.object.content
@@ -19,12 +19,12 @@
 
         .col-md-12
           %h4 Sub Thumbnails
-          %ul.proto-sub-list.list-group#sub_image_uploder
+          %ul.proto-sub-list.list-group.sub_image_uploder
             = f.fields_for :captured_images do |image|
               - if image.object != @prototype.captured_images[0]
                 %li.list-group-item.col-md-4.edit_subs
                   .image-upload
-                    = image_tag(image.object.content, style: "width: 100%; height: 100%;", id: "sub_image")
+                    = image_tag(image.object.content, style: "width: 100%; height: 100%;", class: "sub_image")
                     = image.file_field :content
                     = image.hidden_field :status, value: "sub"
 

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -1,0 +1,39 @@
+.container.proto-new
+  = form_for @prototype do |f|
+    = f.hidden_field :user_id, value: current_user.id
+    .col-md-8.col-md-offset-2
+      %header.row.user-nav.row
+        .col-md-12
+          %h4 Title
+          .proto-new-title
+            = f.text_field :title, required: true, autofocus: true, placeholder: "Input Title"
+      .row
+        .col-md-12
+          %h4 Main Thumbnail
+          .cover-image-upload#main_image_uploader
+            = image_tag(@prototype.set_main_thumbnail, style: "width: 100%; height: 100%;", id: "main_image")
+            = f.fields_for :captured_images  do |image|
+              - if image.index == 0
+                = image.file_field :content, value: image.object.content
+                = image.hidden_field :status, value: "main"
+
+        .col-md-12
+          %h4 Sub Thumbnails
+          %ul.proto-sub-list.list-group#sub_image_uploder
+            = f.fields_for :captured_images do |image|
+              - if image.object != @prototype.captured_images[0]
+                %li.list-group-item.col-md-4.edit_subs
+                  .image-upload
+                    = image_tag(image.object.content, style: "width: 100%; height: 100%;", id: "sub_image")
+                    = image.file_field :content
+                    = image.hidden_field :status, value: "sub"
+
+      .row.proto-description
+        .col-md-12
+          %h4 Catch Copy
+          = f.text_field :catch_copy, require: true, placeholder: "Input Catch Copy"
+        .col-md-12
+          %h4 Concept
+          = f.text_area :concept, require: true, placeholder: "Input Concept"
+      .row.text-center.proto-btn
+        = f.submit "UPDATE", id: "button", class: "btn btn-lg btn-primary btn-block"

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -10,19 +10,19 @@
       .row
         .col-md-12
           %h4 Main Thumbnail
-          .cover-image-upload#main_image_uploader
+          .cover-image-upload.main_image_uploader
             = f.fields_for :captured_images do |image|
-              %img
+              = image_tag(src= "", style: "width: 100%; height: 100%;", class: "main_image")
               = image.file_field :content, required: true
               = image.hidden_field :status, value: "main"
         .col-md-12
           %h4 Sub Thumbnails
-          %ul.proto-sub-list.list-group
+          %ul.proto-sub-list.list-group.sub_image_uploder
             - 3.times do |i|
               %li.list-group-item.col-md-4
                 .image-upload
                   = f.fields_for :captured_images do |image|
-                    %img
+                    = image_tag(src= "", style: "width: 100%; height: 100%;", class: "sub_image")
                     = image.file_field :content
                     = image.hidden_field :status, value: "sub"
       .row.proto-description

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'prototypes#index'
 
-  resources :prototypes, only: [:index, :new, :create, :show, :destroy] do
+  resources :prototypes do
     resources :captured_images, only: [:create, :update, :destroy]
   end
   resources :users, only: [:show, :edit, :update]


### PR DESCRIPTION
プロトタイプ編集機能を実装しました
目的：プロトタイプを編集できたら間違いとかあった時便利よね

何をしたか：
・rootでprototypeコントローラーのeditとupdateを追加した
・prototypeコントロローラーでeditにはprototypeの情報を入れ
updateにはeditから送られてきた情報をupdateさせる。
その時のparamsはcaputuded_imageのidが必要だっため、専用のメソッドを追
加
成功したらトップに戻りアラート表示

・editのviewページを追加
・editのjsファイルを追加

JSファイル内での処理
・メイン、サブ画像をプレビュー表示
・すでに投稿されているサブ画像の数を取得して、画像投稿フォームを差し込む数を決めている。
・画像投稿フォーム、画像投稿フォーム追加ボタンの差し込み
・画像投稿フォーム追加ボタンを押したときの、処理（画像投稿フォームの表示）

##コード汚くてすいません！！